### PR TITLE
fix: Remove support for parsing config.schema.json as YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ajv": "^7.0.1",
     "dotenv": "^8.2.0",
     "js-yaml": "^3.14.1",
+    "json5": "^2.1.3",
     "typescript": "4.1.2"
   },
   "devDependencies": {

--- a/template-support/index.ts
+++ b/template-support/index.ts
@@ -19,7 +19,7 @@ function loadAdaptableConfigSchema() {
     const configPath = path.join(".", ".adaptable", "config.schema.json");
     if (!fs.existsSync(configPath)) return undefined;
     const schemaText = fs.readFileSync(configPath);
-    const schema = parseYAMLorJSON(schemaText);
+    const schema = JSON.parse(schemaText.toString());
     if (typeof schema !== "object" || Array.isArray(schema)) {
         throw new Error("Invalid Adaptable template config schema, not an object");
     }

--- a/template-support/index.ts
+++ b/template-support/index.ts
@@ -1,9 +1,10 @@
 /* eslint-disable import/prefer-default-export */
-import * as fs from "fs";
-import * as path from "path";
-import { safeLoad } from "js-yaml";
 import Ajv from "ajv";
 import dotenv from "dotenv";
+import * as fs from "fs";
+import { safeLoad } from "js-yaml";
+import { parse } from "json5";
+import * as path from "path";
 
 dotenv.config();
 
@@ -11,7 +12,7 @@ function parseYAMLorJSON(buf: Buffer | string) {
     try {
         return safeLoad(buf.toString());
     } catch (e) {
-        return JSON.parse(buf.toString());
+        return parse(buf.toString());
     }
 }
 
@@ -19,7 +20,7 @@ function loadAdaptableConfigSchema() {
     const configPath = path.join(".", ".adaptable", "config.schema.json");
     if (!fs.existsSync(configPath)) return undefined;
     const schemaText = fs.readFileSync(configPath);
-    const schema = JSON.parse(schemaText.toString());
+    const schema = parse(schemaText.toString());
     if (typeof schema !== "object" || Array.isArray(schema)) {
         throw new Error("Invalid Adaptable template config schema, not an object");
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,6 +1614,13 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
I disabled the ability to parse `.adaptable/config.schema.json` as YAML. I also moved to using the JSON5 parser instead of the builtin JSON parser. I think in general, we should avoid the built in `JSON.parse`. It not only gives users some more flexibility on comments and such, but it also gives better error messages. 